### PR TITLE
add sad path spec for github login

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -13,12 +13,17 @@ class SessionsController < ApplicationController
         flash.now[:error] = "Invalid credentials"
         render :new
       end
-    elsif @user = User.from_omniauth(request.env["omniauth.auth"])
-      session[:user_id] = @user.id
-      redirect_to root_path
+    elsif request.env["omniauth.auth"]
+      if @user = User.from_omniauth(request.env["omniauth.auth"])
+        session[:user_id] = @user.id
+        redirect_to root_path
+      else
+        flash[:error] = "Invalid Github. Do you already have an account with us?"
+        redirect_to login_path
+      end
     else
-      flash.now[:error] = "Invalid credentials"
-      render :new
+      flash[:error] = "Something went wrong"
+      render file: "public/404"
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ApplicationRecord
   has_secure_password validations: false, if: "uid"
+  validates :email, uniqueness: true
   validates :email, confirmation: true, if: "uid.nil?", on: :create
   validates :email_confirmation, presence: true, if: "uid.nil?", on: :create
   validates :password, presence: true, confirmation: true, if: "uid.nil?", on: :create

--- a/spec/features/user_logs_in_with_github_spec.rb
+++ b/spec/features/user_logs_in_with_github_spec.rb
@@ -1,11 +1,10 @@
 require "rails_helper"
 
 RSpec.feature "User logs in with GitHub" do
-  before do
-    mock_auth_hash
-  end
   context "they use valid login credentials" do
     scenario "they are redirected to the homepage" do
+      mock_auth_hash
+
       visit '/login'
 
       expect(page.status_code).to eq 200
@@ -15,6 +14,25 @@ RSpec.feature "User logs in with GitHub" do
       expect(current_path).to eq "/"
       expect(page).to have_content "Cool Guy"
       expect(page).to have_content "Logout"
+    end
+  end
+
+  context "when an internal account with that email exists" do
+    scenario "and they are redirected to login path" do
+      user = create(:user, email: "coolguy@lithub.com", 
+                    email_confirmation: "coolguy@lithub.com")
+
+      mock_auth_hash
+
+      visit '/login'
+
+      click_button "Sign in with GitHub"
+
+      expect(current_path).to eq "/login"
+
+      within "#flash_error" do
+        expect(page).to have_content "Invalid Github. Do you already have an account with us?"
+      end
     end
   end
 end


### PR DESCRIPTION
added a test for scenario in which a user tries to login
with a github account when they already have an internal account
associated with that email

closes #13 
