### PR TITLE
clean up Price Comparison Tool

### DIFF
--- a/app/controllers/admin/price_comparison_controller.rb
+++ b/app/controllers/admin/price_comparison_controller.rb
@@ -1,7 +1,7 @@
 class Admin::PriceComparisonController < Admin::BaseController
   def index
     @walmart_products = WalmartProductSearch.get_all(params[:query])
-
+    @query = params[:query]
     upcs_array = @walmart_products.map(&:upc)
 
     @amazon_products = AmazonProductSearch.get_matching(upcs_array)

--- a/app/models/product_presenter.rb
+++ b/app/models/product_presenter.rb
@@ -1,0 +1,23 @@
+class ProductPresenter
+  attr_reader :template
+
+  def initialize(walmart_product, amazon_products, template)
+    @walmart_product = walmart_product
+    @amazon_products = amazon_products
+    @template = template
+  end
+
+  def matching_amazon_product
+    @amazon_products.find do |amazon_product|
+      amazon_product.upc == @walmart_product.upc
+    end
+  end
+
+  def matching_amazon_price
+    if matching_amazon_product
+      template.link_to(matching_amazon_product.price, matching_amazon_product.url)
+    else
+      "Not available"
+    end
+  end
+end

--- a/app/models/walmart_product.rb
+++ b/app/models/walmart_product.rb
@@ -1,5 +1,5 @@
 class WalmartProduct
-  attr_reader :name, :walmart_id, :price, :image_path, :upc
+  attr_reader :name, :walmart_id, :price, :image_path, :upc, :url
 
   def initialize(product_data)
     @name = clean_name(product_data.dig(:name))
@@ -7,6 +7,7 @@ class WalmartProduct
     @price = product_data.dig(:salePrice)
     @image_path = product_data.dig(:thumbnailImage)
     @upc = product_data.dig(:upc)
+    @url = product_data.dig(:productUrl)
   end
 
   def clean_name(name)

--- a/app/views/admin/price_comparison/index.html.erb
+++ b/app/views/admin/price_comparison/index.html.erb
@@ -1,40 +1,24 @@
-<h1>Price Comparison</h1>
+<div class="container">
+  <h1>Price Comparison for "<%= @query %>"</h1>
+  <table class="price_comparison_table table table-striped">
+     <thead>
+      <tr>
+        <th>Image</th>
+        <th>UPC</th>
+        <th>Name</th>
+        <th>Walmart Price</th>
+        <th>Amazon Price</th>
+      </tr>
+    </thead>
 
-<table class="walmart_price_comparison_table">
-   <thead>
-    <tr>
-      <th>Image</th>
-      <th>Name</th>
-      <th>UPC</th>
-      <th>Price</th>
-    </tr>
-  </thead>
-
-  <% @walmart_products.each do |walmart_product| %>
-    <tr>
-      <td><%= image_tag walmart_product.image_path %></td>
-      <td><%= walmart_product.upc %></td>
-      <td><%= walmart_product.name %></td>
-      <td>$<%= walmart_product.price %></td>
-    </tr>
-  <% end %>
-
-</table>
-
-<table class="amazon_price_comparison_table">
-   <thead>
-    <tr>
-      <th>Name</th>
-      <th>UPC</th>
-      <th>Prime</th>
-      <th>Price</th>
-    </tr>
-  </thead>
-  <% @amazon_products.each do |amazon_product| %>
-    <tr>
-      <td><%= link_to amazon_product.name, amazon_product.url %></td>
-      <td><%= amazon_product.upc %></td>
-      <td><%= amazon_product.is_prime? %></td>
-      <td><%= amazon_product.price %></td>
-    </tr>
-  <% end %>
+    <% @walmart_products.each do |walmart_product| %>
+      <tr>
+        <td><%= image_tag walmart_product.image_path %></td>
+        <td><%= walmart_product.upc %></td>
+        <td><%= walmart_product.name %></td>
+        <td><%= link_to "$#{walmart_product.price}", walmart_product.url %></td>
+        <td><%= ProductPresenter.new(walmart_product, @amazon_products, self).matching_amazon_price %></td>
+      </tr>
+    <% end %>
+  </table>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,8 +1,6 @@
 <h1>Admin Dashboard</h1>
 <%= link_to "Pending Fulfillments", admin_fulfillments_path %>
 
-<%= link_to "Price Comparison Tool", admin_price_comparison_path %>
-
 <p>Price Comparison Tool</p>
 
 <%= form_tag "/admin/price_comparison", method: "get" do %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -11,7 +11,7 @@
     </div>
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav navbar-right" id="navbar-links">
-        <li><a><%= "Get Stuffed, "+ current_user.first_name if current_user %></a></li>
+        <li><a><%= "Welcome, "+ current_user.first_name if current_user %></a></li>
         <li><%= link_to "Logout", logout_path, method: :delete if current_user %></li>
         <li><%= link_to "Login", login_path unless current_user %></li>
       </ul>

--- a/spec/features/admin_can_view_price_comparison_spec.rb
+++ b/spec/features/admin_can_view_price_comparison_spec.rb
@@ -12,11 +12,7 @@ RSpec.feature "admin can see price comparison" do
 
     expect(current_path).to eq admin_price_comparison_path
 
-    within ".walmart_price_comparison_table tr:nth-child(2)" do
-      expect(page).to have_content("041570109489")
-    end    
-
-    within ".amazon_price_comparison_table tr:nth-child(2)" do
+    within ".price_comparison_table tr:nth-child(2)" do
       expect(page).to have_content("041570109489")
     end
   end

--- a/spec/features/visitor_create_account_spec.rb
+++ b/spec/features/visitor_create_account_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "visitor can create an internal account" do
       select(location, from: "cubby_location")
       select(column, from: "cubby_column")
       select(row, from: "cubby_row")
-      
+
       click_button "Register Cubby"
 
       expect(current_path).to eq (dashboard_path)
@@ -49,7 +49,7 @@ RSpec.feature "visitor can create an internal account" do
       end
 
       within("nav") do
-        expect(page).to have_content("Get Stuffed, Neight")
+        expect(page).to have_content("Welcome, Neight")
         expect(page).to_not have_content("Login")
         expect(page).to have_content("Logout")
       end


### PR DESCRIPTION
remove separate amazon price table
updated to have one table for amazon and walmart prices
added url to walmart_product model
added presenter to find matching amazon product/price
removed extra link to price tool from admin dash
updated navbar welcome message
updated existing tests to reflect changes

closes #40 
